### PR TITLE
Updating for renaming of codegangsta/cli to urfave/cli

### DIFF
--- a/cmd/easypki/main.go
+++ b/cmd/easypki/main.go
@@ -28,7 +28,7 @@ import (
 
 	"encoding/pem"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/jpicht/easypki/pkg/certificate"
 	"github.com/jpicht/easypki/pkg/easypki"
 	"github.com/jpicht/easypki/pkg/store"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/boltdb/bolt v1.3.1
-	github.com/codegangsta/cli v1.20.0
+	github.com/urfave/cli v1.20.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/kr/pretty v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd // indirect


### PR DESCRIPTION
Codegangsta/cli renamed to urfave/cli this is an update so that it can continue to be installed by go get